### PR TITLE
Export scaling system

### DIFF
--- a/SADXModLoader/SADXModLoader.vcxproj
+++ b/SADXModLoader/SADXModLoader.vcxproj
@@ -53,6 +53,7 @@
     <ClInclude Include="include\SADXModInfo.h" />
     <ClInclude Include="include\SADXStructsNew.h" />
     <ClInclude Include="include\SADXVariablesNew.h" />
+    <ClInclude Include="include\ScaleInfo.h" />
     <ClInclude Include="polybuff.h" />
     <ClInclude Include="prs.h" />
     <ClInclude Include="include\d3d8types.h" />

--- a/SADXModLoader/SADXModLoader.vcxproj.filters
+++ b/SADXModLoader/SADXModLoader.vcxproj.filters
@@ -182,6 +182,9 @@
     <ClInclude Include="include\SADXEnumsNew.h">
       <Filter>Header Files\include</Filter>
     </ClInclude>
+    <ClInclude Include="include\ScaleInfo.h">
+      <Filter>Header Files\include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SADXModLoader.rc">

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1252,7 +1252,7 @@ void LoadDLLData(const wchar_t* filename, const std::wstring &mod_dir)
 	ProcessDLLData(filename, mod_dir);
 }
 
-void PushScaleUI(ScaleAlign align, bool is_background, float ratio_h, float ratio_v)
+void PushScaleUI(uiscale::Align align, bool is_background, float ratio_h, float ratio_v)
 {
 	uiscale::initialize_common(); // make sure sprite functions are hooked
 	uiscale::scale_push(align, is_background, ratio_h, ratio_v);
@@ -1263,14 +1263,14 @@ void PopScaleUI()
 	uiscale::scale_pop();
 }
 
-void SetScaleFillMode(ScaleFillMode mode)
+void SetScaleFillMode(uiscale::FillMode mode)
 {
-	uiscale::bg_fill = static_cast<uiscale::FillMode>(mode);
+	uiscale::bg_fill = mode;
 }
 
-ScaleFillMode GetScaleFillMode()
+uiscale::FillMode GetScaleFillMode()
 {
-	return  static_cast<ScaleFillMode>(uiscale::bg_fill);
+	return uiscale::bg_fill;
 }
 
 static const HelperFunctions helperFunctions =

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1254,6 +1254,7 @@ void LoadDLLData(const wchar_t* filename, const std::wstring &mod_dir)
 
 void PushScaleUI(ScaleAlign align, bool is_background, float ratio_h, float ratio_v)
 {
+	uiscale::initialize_common(); // make sure sprite functions are hooked
 	uiscale::scale_push(align, is_background, ratio_h, ratio_v);
 }
 

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1252,6 +1252,26 @@ void LoadDLLData(const wchar_t* filename, const std::wstring &mod_dir)
 	ProcessDLLData(filename, mod_dir);
 }
 
+void PushScaleUI(ScaleAlign align, bool is_background, float ratio_h, float ratio_v)
+{
+	uiscale::scale_push(align, is_background, ratio_h, ratio_v);
+}
+
+void PopScaleUI()
+{
+	uiscale::scale_pop();
+}
+
+void SetScaleFillMode(ScaleFillMode mode)
+{
+	uiscale::bg_fill = static_cast<uiscale::FillMode>(mode);
+}
+
+ScaleFillMode GetScaleFillMode()
+{
+	return  static_cast<ScaleFillMode>(uiscale::bg_fill);
+}
+
 static const HelperFunctions helperFunctions =
 {
 	ModLoaderVer,
@@ -1279,6 +1299,10 @@ static const HelperFunctions helperFunctions =
 	&LoadEXEData,
 	&LoadDLLData,
 	&_ReplaceFileForce,
+	&PushScaleUI,
+	&PopScaleUI,
+	&SetScaleFillMode,
+	&GetScaleFillMode
 };
 
 static const char* const dlldatakeys[] = {

--- a/SADXModLoader/hudscale.cpp
+++ b/SADXModLoader/hudscale.cpp
@@ -120,8 +120,7 @@ static Trampoline* ChaoParamWindowExecutor_t;
 static Trampoline* ChaoSelectWindowExecutor_t;
 static Trampoline* AL_ChaoParamWindowExecutor_t;
 static Trampoline* late_exec_t;
-static Trampoline* DrawGameGearScreen_t;
-static Trampoline* DrawGameGearSelect_t;
+static Trampoline* MiniGameCollectionMenu_t;
 
 #pragma endregion
 
@@ -699,62 +698,9 @@ static void __cdecl late_exec_r()
 	scale_enable();
 }
 
-static void __cdecl DrawGameGearScreen_o(int a1)
+static void __cdecl MiniGameCollectionMenu_r(ObjectMaster* a1)
 {
-	auto orig = DrawGameGearScreen_t->Target();
-
-	__asm
-	{
-		mov ecx, a1
-		call orig
-	}
-}
-
-static void __cdecl DrawGameGearScreen_r(int a1)
-{
-	scale_push(Align::center, false);
-	DrawGameGearScreen_o(a1);
-	scale_pop();
-}
-
-static void __declspec(naked) DrawGameGearScreen_asm()
-{
-	__asm
-	{
-		push ecx
-		call DrawGameGearScreen_r
-		pop ecx
-		ret
-	}
-}
-
-static void __cdecl DrawGameGearSelect_o(int a1)
-{
-	auto orig = DrawGameGearSelect_t->Target();
-
-	__asm
-	{
-		mov ecx, a1
-		call orig
-	}
-}
-
-static void __cdecl DrawGameGearSelect_r(int a1)
-{
-	scale_push(Align::center, false);
-	DrawGameGearSelect_o(a1);
-	scale_pop();
-}
-
-static void __declspec(naked) DrawGameGearSelect_asm()
-{
-	__asm
-	{
-		push ecx
-		call DrawGameGearSelect_r
-		pop ecx
-		ret
-	}
+	scale_trampoline(Align::center, false, MiniGameCollectionMenu_r, MiniGameCollectionMenu_t, a1);
 }
 
 static void __cdecl DrawTitleScreen_o(void* a1)
@@ -1098,8 +1044,7 @@ void hudscale::initialize()
 	// GameGear
 	WriteData(reinterpret_cast<const float**>(0x0070144D), &patch_dummy);
 	WriteData(reinterpret_cast<const float**>(0x0070146F), &patch_dummy);
-	DrawGameGearScreen_t = new Trampoline(0x006FD4D0, 0x006FD4D5, DrawGameGearScreen_asm);
-	DrawGameGearSelect_t = new Trampoline(0x006FD650, 0x006FD655, DrawGameGearSelect_asm);
+	MiniGameCollectionMenu_t = new Trampoline(0x0050C010, 0x0050C017, MiniGameCollectionMenu_r);
 	
 	// Honeycomb transition
 	WriteData(reinterpret_cast<const float**>(0x006FF5C8), &patch_dummy);

--- a/SADXModLoader/hudscale.cpp
+++ b/SADXModLoader/hudscale.cpp
@@ -121,6 +121,9 @@ static Trampoline* ChaoSelectWindowExecutor_t;
 static Trampoline* AL_ChaoParamWindowExecutor_t;
 static Trampoline* late_exec_t;
 static Trampoline* MiniGameCollectionMenu_t;
+static Trampoline* DrawGameOver_t;
+static Trampoline* DrawGameOverTC_t;
+static Trampoline* DrawGameOverHH_t;
 
 #pragma endregion
 
@@ -703,6 +706,99 @@ static void __cdecl MiniGameCollectionMenu_r(ObjectMaster* a1)
 	scale_trampoline(Align::center, false, MiniGameCollectionMenu_r, MiniGameCollectionMenu_t, a1);
 }
 
+static void __cdecl DrawGameOver_o(int a1)
+{
+	auto orig = DrawGameOver_t->Target();
+
+	__asm
+	{
+		mov esi, a1
+		call orig
+	}
+}
+
+static void __cdecl DrawGameOver_r(int a1)
+{
+	scale_push(Align::center, false);
+	DrawGameOver_o(a1);
+	scale_pop();
+}
+
+static void __declspec(naked) DrawGameOver_asm()
+{
+	__asm
+	{
+		push esi
+		call DrawGameOver_r
+		pop esi
+		ret
+	}
+}
+
+static void __cdecl DrawGameOverTC_o(int a1)
+{
+	auto orig = DrawGameOverTC_t->Target();
+
+	__asm
+	{
+		mov esi, a1
+		call orig
+	}
+}
+
+static void __cdecl DrawGameOverTC_r(int a1)
+{
+	scale_push(Align::center, false);
+	DrawGameOverTC_o(a1);
+	scale_pop();
+}
+
+static void __declspec(naked) DrawGameOverTC_asm()
+{
+	__asm
+	{
+		push esi
+		call DrawGameOverTC_r
+		pop esi
+		ret
+	}
+}
+
+static void __cdecl DrawGameOverHH_o(int a1)
+{
+	auto orig = DrawGameOverHH_t->Target();
+
+	__asm
+	{
+		mov esi, a1
+		call orig
+	}
+}
+
+static void __cdecl DrawGameOverHH_r(int a1)
+{
+	scale_push(Align::center, false);
+	DrawGameOverHH_o(a1);
+	scale_pop();
+}
+
+static void __declspec(naked) DrawGameOverHH_asm()
+{
+	__asm
+	{
+		push esi
+		call DrawGameOverHH_r
+		pop esi
+		ret
+	}
+}
+
+static void DrawRect_DrawNowMaybe_GameOverHH(float left, float top, float right, float bottom, float depth, int color) {
+	uiscale::scale_disable();
+	DrawRect_DrawNowMaybe(left, top, right, bottom, depth, color);
+	uiscale::scale_enable();
+}
+
 static void __cdecl DrawTitleScreen_o(void* a1)
 {
 	auto orig = DrawTitleScreen_t->Target();
@@ -831,7 +927,7 @@ void hudscale::update() {
 
 	// Black Market Item Preview
 	WriteData(reinterpret_cast<float*>(0x00726211), preview_animal_hat_shell);
-	WriteData(reinterpret_cast<float*>(0x007261CF), preview_pacifier);
+	WriteData(reinterpret_cast<float*>(0x007261CF), preview_pacifier);	
 }
 
 static void InitializeChaoHUDs() {
@@ -1057,6 +1153,14 @@ void hudscale::initialize()
 	WriteData(reinterpret_cast<const float**>(0x006FF611), &patch_dummy);
 	WriteData(reinterpret_cast<const float**>(0x006FF632), &patch_dummy);
 	WriteData(reinterpret_cast<const float**>(0x006FF657), &patch_dummy);
+
+	// Game Over
+	WriteData(reinterpret_cast<float**>(0x00625ED6), &scale_v);
+	WriteData(reinterpret_cast<float**>(0x00625EF6), &scale_h);
+	WriteCall(reinterpret_cast<void*>(0x00625F05), DrawRect_DrawNowMaybe_GameOverHH);
+	DrawGameOver_t   = new Trampoline(0x0042BFD0, 0x0042BFD8, DrawGameOver_asm);   // Normal
+	DrawGameOverTC_t = new Trampoline(0x004DACC0, 0x004DACC5, DrawGameOverTC_asm); // Twinkle Circuit
+	DrawGameOverHH_t = new Trampoline(0x00625D00, 0x00625D09, DrawGameOverHH_asm); // Hedgehog Hammer
 
 	InitializeChaoHUDs();
 	hudscale::update();

--- a/SADXModLoader/hudscale.cpp
+++ b/SADXModLoader/hudscale.cpp
@@ -863,6 +863,9 @@ static void InitializeChaoHUDs() {
 	WriteData(reinterpret_cast<double*>(0x0088A5D0), 24.0); // Fix sprite padding in AL_ChaoParamWindowDisplayer
 	WriteData(reinterpret_cast<const float**>(0x0072C6D3), &patch_dummy); // BlueButtonCS height
 	WriteData(reinterpret_cast<const float**>(0x0072C6EC), &patch_dummy); // BlueButtonCS width
+	WriteData(reinterpret_cast<const float**>(0x007691CC), &float640); // Chao select 3D placement patch
+	WriteData(reinterpret_cast<const float**>(0x00747115), &float640); // Chao reccord 3D placement patch
+	WriteData(reinterpret_cast<const float**>(0x00767CF1), &float640); // Chao param 3D placement patch
 	AL_CreateChaoSelectMenu_t                   = new Trampoline(0x007491D0, 0x007491D5, AL_CreateChaoSelectMenu_r);
 	AL_EntranceMenuBackGroundDisplayer_t        = new Trampoline(0x0074AB40, 0x0074AB47, AL_EntranceMenuBackGroundDisplayer_r);
 	AL_EntranceMenuLargeTitleBarDisplayer_t     = new Trampoline(0x00749830, 0x00749835, AL_EntranceMenuLargeTitleBarDisplayer_r);

--- a/SADXModLoader/hudscale.cpp
+++ b/SADXModLoader/hudscale.cpp
@@ -124,6 +124,7 @@ static Trampoline* MiniGameCollectionMenu_t;
 static Trampoline* DrawGameOver_t;
 static Trampoline* DrawGameOverTC_t;
 static Trampoline* DrawGameOverHH_t;
+static Trampoline* RecapBackground_Main_t;
 
 #pragma endregion
 
@@ -799,6 +800,23 @@ static void DrawRect_DrawNowMaybe_GameOverHH(float left, float top, float right,
 	uiscale::scale_enable();
 }
 
+static void __cdecl RecapBackground_Main_r(ObjectMaster* a1)
+{
+	scale_trampoline(Align::center, true, RecapBackground_Main_r, RecapBackground_Main_t, a1);
+}
+
+void __cdecl njDrawTextureMemList_NoSkippedFrames_RecapText(NJS_TEXTURE_VTX* points, Int count, Uint32 gbix, Int flag)
+{
+	uiscale::scale_push(Align::center, false);
+
+	NJS_TEXTURE_VTX* new_points = new NJS_TEXTURE_VTX[count];
+	memcpy(new_points, points, sizeof(NJS_TEXTURE_VTX) * count);
+	njDrawTextureMemList_NoSkippedFrames(new_points, count, gbix, flag);
+	delete[] new_points;
+
+	uiscale::scale_pop();
+}
+
 static void __cdecl DrawTitleScreen_o(void* a1)
 {
 	auto orig = DrawTitleScreen_t->Target();
@@ -1162,6 +1180,12 @@ void hudscale::initialize()
 	DrawGameOverTC_t = new Trampoline(0x004DACC0, 0x004DACC5, DrawGameOverTC_asm); // Twinkle Circuit
 	DrawGameOverHH_t = new Trampoline(0x00625D00, 0x00625D09, DrawGameOverHH_asm); // Hedgehog Hammer
 
+	// Recap
+	WriteData(reinterpret_cast<const float**>(0x0064287A), &patch_dummy);
+	WriteData(reinterpret_cast<const float**>(0x00642896), &patch_dummy);
+	WriteCall(reinterpret_cast<void*>(0x00642427), njDrawTextureMemList_NoSkippedFrames_RecapText);
+	RecapBackground_Main_t = new Trampoline(0x00643C90, 0x00643C95, RecapBackground_Main_r);
+	
 	InitializeChaoHUDs();
 	hudscale::update();
 }

--- a/SADXModLoader/include/SADXModInfo.h
+++ b/SADXModLoader/include/SADXModInfo.h
@@ -8,6 +8,7 @@
 
 #include "SADXStructs.h"
 #include "SADXStructsNew.h"
+#include "ScaleInfo.h"
 #include <string>
 
 // SADX Mod Loader API version.
@@ -36,25 +37,6 @@ struct PointerList
 {
 	const PointerInfo *Pointers;
 	int Count;
-};
-
-enum ScaleAlign : Uint8
-{
-	Automatic,
-	HorizontalCenter = 1 << 0,
-	VerticalCenter = 1 << 1,
-	Center = HorizontalCenter | VerticalCenter,
-	Left = 1 << 2,
-	Top = 1 << 3,
-	Right = 1 << 4,
-	Bottom = 1 << 5
-};
-
-enum ScaleFillMode : Uint8
-{
-	Stretch = 0,
-	Fit = 1,
-	Fill = 2
 };
 
 #undef ReplaceFile // Windows function macro
@@ -150,7 +132,7 @@ struct HelperFunctions
 	* @param ratio_h: The horizontal ratio of the frame (1.0f by default.)
 	* @param ratio_v: The vertical ratio of the frame (1.0f by default.)
 	*/
-	void(__cdecl* PushScaleUI)(ScaleAlign align, bool is_background, float ratio_h, float ratio_v);
+	void(__cdecl* PushScaleUI)(uiscale::Align align, bool is_background, float ratio_h, float ratio_v);
 
 	// Removes the latest UI scale method from the queue.
 	// Requires version >= 11.
@@ -158,11 +140,11 @@ struct HelperFunctions
 
 	// Force a specific filling method for background sprites, make sure to reset the original value once you're done.
 	// Requires version >= 11.
-	void(__cdecl* SetScaleFillMode)(ScaleFillMode mode);
+	void(__cdecl* SetScaleFillMode)(uiscale::FillMode mode);
 
 	// Returns the current filling method for background sprites.
 	// Requires version >= 11.
-	ScaleFillMode(__cdecl* GetScaleFillMode)();
+	uiscale::FillMode(__cdecl* GetScaleFillMode)();
 };
 
 typedef void(__cdecl *ModInitFunc)(const char *path, const HelperFunctions &helperFunctions);

--- a/SADXModLoader/include/SADXModInfo.h
+++ b/SADXModLoader/include/SADXModInfo.h
@@ -11,7 +11,7 @@
 #include <string>
 
 // SADX Mod Loader API version.
-static const int ModLoaderVer = 10;
+static const int ModLoaderVer = 11;
 
 struct PatchInfo
 {
@@ -38,7 +38,27 @@ struct PointerList
 	int Count;
 };
 
+enum ScaleAlign : Uint8
+{
+	Automatic,
+	HorizontalCenter = 1 << 0,
+	VerticalCenter = 1 << 1,
+	Center = HorizontalCenter | VerticalCenter,
+	Left = 1 << 2,
+	Top = 1 << 3,
+	Right = 1 << 4,
+	Bottom = 1 << 5
+};
+
+enum ScaleFillMode : Uint8
+{
+	Stretch = 0,
+	Fit = 1,
+	Fill = 2
+};
+
 #undef ReplaceFile // Windows function macro
+
 struct HelperFunctions
 {
 	// The version of the structure.
@@ -118,6 +138,33 @@ struct HelperFunctions
 	// Replaces the source file with the destination file without checking if the destination file is also being replaced.
 	// Requires version >= 10.
 	void(__cdecl* ReplaceFileForce)(const char* src, const char* dst);
+
+	/**
+	* @brief Adds a UI scale method to the queue, will scale sprites drawn between this and PopScaleUI.
+	*
+	* This will scale all of the sprite drawing functions based on 640x480 frame by default.
+	* It is used by the Mod Loader scaling system, and requires the option to be enabled.
+	* If another method is added, it takes the priority.
+	* Requires version >= 11.
+	*
+	* @param align: The sprite anchor that the 640x480 frame is attached to.
+	* @param background: Treat the sprite as background, which can scale differently based on the user preferences.
+	* @param ratio_h: The horizontal ratio of the frame, 1.0f by default, 1.33f for a 16:9 menu for example.
+	* @param ratio_v: The vertical ratio of the frame, 1.0f by default.
+	*/
+	void(__cdecl* PushScaleUI)(ScaleAlign align, bool is_background, float ratio_h, float ratio_v);
+
+	// Removes the latest UI scale method from the queue.
+	// Requires version >= 11.
+	void(__cdecl* PopScaleUI)();
+
+	// Force a specific filling method for background sprites, make sure to reset the original value once you're done.
+	// Requires version >= 11.
+	void(__cdecl* SetScaleFillMode)(ScaleFillMode mode);
+
+	// Returns the current filling method for background sprites.
+	// Requires version >= 11.
+	ScaleFillMode(__cdecl* GetScaleFillMode)();
 };
 
 typedef void(__cdecl *ModInitFunc)(const char *path, const HelperFunctions &helperFunctions);

--- a/SADXModLoader/include/SADXModInfo.h
+++ b/SADXModLoader/include/SADXModInfo.h
@@ -9,7 +9,6 @@
 #include "SADXStructs.h"
 #include "SADXStructsNew.h"
 #include "ScaleInfo.h"
-#include <string>
 
 // SADX Mod Loader API version.
 static const int ModLoaderVer = 11;

--- a/SADXModLoader/include/SADXModInfo.h
+++ b/SADXModLoader/include/SADXModInfo.h
@@ -140,17 +140,15 @@ struct HelperFunctions
 	void(__cdecl* ReplaceFileForce)(const char* src, const char* dst);
 
 	/**
-	* @brief Adds a UI scale method to the queue, will scale sprites drawn between this and PopScaleUI.
+	* @brief Adds a UI scale method to the queue, scaling all sprites drawn between this and PopScaleUI.
 	*
-	* This will scale all of the sprite drawing functions based on 640x480 frame by default.
-	* It is used by the Mod Loader scaling system, and requires the option to be enabled.
-	* If another method is added, it takes the priority.
+	* By default, draw your sprites as if they were in a 640x480 window and the mod loader will handle scaling.
 	* Requires version >= 11.
 	*
-	* @param align: The sprite anchor that the 640x480 frame is attached to.
-	* @param background: Treat the sprite as background, which can scale differently based on the user preferences.
-	* @param ratio_h: The horizontal ratio of the frame, 1.0f by default, 1.33f for a 16:9 menu for example.
-	* @param ratio_v: The vertical ratio of the frame, 1.0f by default.
+	* @param align: The frame anchor.
+	* @param background: Indicates if the frame should be treated as background.
+	* @param ratio_h: The horizontal ratio of the frame (1.0f by default.)
+	* @param ratio_v: The vertical ratio of the frame (1.0f by default.)
 	*/
 	void(__cdecl* PushScaleUI)(ScaleAlign align, bool is_background, float ratio_h, float ratio_v);
 

--- a/SADXModLoader/include/ScaleInfo.h
+++ b/SADXModLoader/include/ScaleInfo.h
@@ -61,7 +61,8 @@ namespace uiscale
 		Align_Center = Align_Center_Horizontal | Align_Center_Vertical,
 
 		/**
-		 * \brief Automatically align the canvas
+		 * \brief Automatically align the canvas to horizontal and vertical thirds
+		 * of the screen based on the placement of the UI element.
 		 */
 		Align_Automatic = Align_Automatic_Horizontal | Align_Automatic_Vertical
 	};

--- a/SADXModLoader/include/ScaleInfo.h
+++ b/SADXModLoader/include/ScaleInfo.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace uiscale
+{
+
+	// Alignement of scaled sprites (top left by default)
+	enum Align : Uint8
+	{
+		automatic         = 0,      // Guess the anchor based on where the sprite is drawn on screen.
+		horizontal_center = 1 << 0,
+		vertical_center	  = 1 << 1,
+		center            = horizontal_center | vertical_center,
+		left              = 1 << 2,
+		top               = 1 << 3,
+		right             = 1 << 4,
+		bottom            = 1 << 5
+	};
+
+	// Filling method of scaled sprites
+	enum FillMode : Uint8
+	{
+		stretch = 0, // Fill screen by stretching the frame to the sides
+		fit     = 1, // Fit the scaled frame into the screen
+		fill    = 2  // Scale the frame until it fills the screen
+	};
+}

--- a/SADXModLoader/uiscale.cpp
+++ b/SADXModLoader/uiscale.cpp
@@ -598,13 +598,17 @@ void uiscale::initialize_common() {
 		update_parameters();
 		njDrawTextureMemList_init();
 
-		Direct3D_DrawQuad_t      = new Trampoline(0x0077DE10, 0x0077DE18, Direct3D_DrawQuad_r);
-		njDrawPolygon_t          = new Trampoline(0x0077DBC0, 0x0077DBC5, njDrawPolygon_r);
-		njDrawSprite2D_Queue_t   = new Trampoline(0x00404660, 0x00404666, njDrawSprite2D_Queue_r);
-		Draw2DLinesMaybe_Queue_t = new Trampoline(0x00404490, 0x00404496, Draw2DLinesMaybe_Queue_r);
-		njDrawTriangle2D_t       = new Trampoline(0x0077E9F0, 0x0077E9F8, njDrawTriangle2D_r);
-		njDrawCircle2D_t         = new Trampoline(0x0077DFC0, 0x0077DFC7, njDrawCircle2D_r);
-		
+		Direct3D_DrawQuad_t           = new Trampoline(0x0077DE10, 0x0077DE18, Direct3D_DrawQuad_r);
+		njDrawPolygon_t               = new Trampoline(0x0077DBC0, 0x0077DBC5, njDrawPolygon_r);
+		njDrawSprite2D_Queue_t        = new Trampoline(0x00404660, 0x00404666, njDrawSprite2D_Queue_r);
+		Draw2DLinesMaybe_Queue_t      = new Trampoline(0x00404490, 0x00404496, Draw2DLinesMaybe_Queue_r);
+		njDrawTriangle2D_t            = new Trampoline(0x0077E9F0, 0x0077E9F8, njDrawTriangle2D_r);
+		njDrawCircle2D_t              = new Trampoline(0x0077DFC0, 0x0077DFC7, njDrawCircle2D_r);
+		chCalcWorldPosFromScreenPos_t = new Trampoline(0x00720B10, 0x00720B17, chCalcWorldPosFromScreenPos_r);
+
+		chDrawBillboardSR_t = new Trampoline(0x0078B070, 0x0078B079, chDrawBillboardSR_r);
+		WriteCall(reinterpret_cast<void*>(reinterpret_cast<size_t>(chDrawBillboardSR_t->Target()) + 4), Direct3D_TextureFilterPoint);
+
 		// njDrawCircle2D call in njDrawTriangle2D_t is already scaled, use original function instead.
 		WriteCall((void*)0x77EA10, njDrawCircle2D_t->Target());
 
@@ -618,11 +622,6 @@ void uiscale::initialize()
 
 	DisplayAllObjects_t = new Trampoline(0x0040B540, 0x0040B546, DisplayAllObjects_r);
 	WriteCall(reinterpret_cast<void*>(reinterpret_cast<size_t>(DisplayAllObjects_t->Target()) + 1), reinterpret_cast<void*>(0x004128F0));
-
-	chDrawBillboardSR_t = new Trampoline(0x0078B070, 0x0078B079, chDrawBillboardSR_r);
-	WriteCall(reinterpret_cast<void*>(reinterpret_cast<size_t>(chDrawBillboardSR_t->Target()) + 4), Direct3D_TextureFilterPoint);
-
-	chCalcWorldPosFromScreenPos_t = new Trampoline(0x00720B10, 0x00720B17, chCalcWorldPosFromScreenPos_r);
 }
 
 void uiscale::setup_background_scale()

--- a/SADXModLoader/uiscale.h
+++ b/SADXModLoader/uiscale.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include "ScaleInfo.h"
 
 namespace uiscale
 {

--- a/SADXModLoader/uiscale.h
+++ b/SADXModLoader/uiscale.h
@@ -4,25 +4,6 @@
 
 namespace uiscale
 {
-	enum Align : Uint8
-	{
-		automatic,
-		horizontal_center = 1 << 0,
-		vertical_center   = 1 << 1,
-		center            = horizontal_center | vertical_center,
-		left              = 1 << 2,
-		top               = 1 << 3,
-		right             = 1 << 4,
-		bottom            = 1 << 5
-	};
-	
-	enum FillMode : Uint8
-	{
-		stretch = 0,
-		fit     = 1,
-		fill    = 2
-	};
-
 	extern FillMode bg_fill;
 	extern FillMode fmv_fill;
 


### PR DESCRIPTION
This puts the needed functions for scaling HUDs outside of the mod loader in HelperFunctions.

What do you think? I made a copy of the scaling enums to avoid having to include `uiscale.h`, I don't know if that's appropriate.