### PR TITLE
TestSpawn implementation

### DIFF
--- a/SADXModLoader/SADXModLoader.vcxproj
+++ b/SADXModLoader/SADXModLoader.vcxproj
@@ -31,6 +31,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="testspawn.cpp" />
     <ClCompile Include="TextureReplacement.cpp" />
     <ClCompile Include="uiscale.cpp" />
   </ItemGroup>
@@ -67,6 +68,7 @@
     <ClInclude Include="MediaFns.hpp" />
     <ClInclude Include="pvmx.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="testspawn.h" />
     <ClInclude Include="TextureReplacement.h" />
     <ClInclude Include="include\UsercallFunctionHandler.h" />
     <ClInclude Include="uiscale.h" />

--- a/SADXModLoader/SADXModLoader.vcxproj.filters
+++ b/SADXModLoader/SADXModLoader.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="bgscale.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="testspawn.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MediaFns.hpp">
@@ -184,6 +187,9 @@
     </ClInclude>
     <ClInclude Include="include\ScaleInfo.h">
       <Filter>Header Files\include</Filter>
+    </ClInclude>
+    <ClInclude Include="testspawn.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1697,8 +1697,6 @@ static void __cdecl InitMods()
 		uiscale::setup_fmv_scale();
 	}
 
-	TestSpawnCheckArgs(helperFunctions);
-
 	polybuff::rewrite_init();
 
 	sadx_fileMap.scanSoundFolder("system\\sounddata\\bgm\\wma");
@@ -2176,6 +2174,8 @@ static void __cdecl InitMods()
 		WriteData((int**)0x42547E, &newlist->Loop);
 	}
 	_MusicList.clear();
+
+	TestSpawnCheckArgs(helperFunctions);
 
 	RaiseEvents(modInitEndEvents);
 	PrintDebug("Finished loading mods\n");

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -12,6 +12,7 @@
 #include "direct3d.h"
 #include "bgscale.h"
 #include "hudscale.h"
+#include "testspawn.h"
 
 using std::deque;
 using std::ifstream;
@@ -1695,6 +1696,8 @@ static void __cdecl InitMods()
 		uiscale::fmv_fill = static_cast<uiscale::FillMode>(fmvFill);
 		uiscale::setup_fmv_scale();
 	}
+
+	TestSpawnCheckArgs(helperFunctions);
 
 	polybuff::rewrite_init();
 

--- a/SADXModLoader/include/SADXFunctions.h
+++ b/SADXModLoader/include/SADXFunctions.h
@@ -314,6 +314,7 @@ FunctionPointer(void, LoadLevelTextures, (__int16 level), 0x4215B0);
 FunctionPointer(void, ShowNoMemoryCardText, (void *a1), 0x421C20);
 FunctionPointer(int, ShowNoMemoryCardText_0, (char *a2), 0x421C70);
 FunctionPointer(int, ShowNoMemoryCardText_1, (char *a2), 0x421CD0);
+VoidFunc(ReadSaveFile, 0x421DE0);
 VoidFunc(WriteSaveFile, 0x421FD0);
 VoidFunc(j_WriteSaveFile, 0x4221D0);
 FunctionPointer(void, LoadFile, (const char *name, LPVOID lpBuffer), 0x422200);

--- a/SADXModLoader/include/SADXVariables.h
+++ b/SADXModLoader/include/SADXVariables.h
@@ -2224,6 +2224,8 @@ DataArray(NJS_TEXLIST *, RegObjTexlists, 0x3B29030, 32);
 DataPointer(NJS_TEXLIST *, CommonTextures, 0x3B290B0);
 DataArray(NJS_TEXLIST *, LevelObjTexlists, 0x3B290B4, 4);
 DataArray(Sint8, LoadedCharTextures, 0x3B290C4, 6);
+DataPointer(int, SaveNum, 0x3B290D8);
+DataPointer(char*, SaveName, 0x3B290DC);
 DataArray(NJS_TEXNAME, ava_dlg_e_TEXNAMES, 0x3B290F0, 14);
 DataPointer(Uint8, CHAORetry, 0x3B291AE);
 DataPointer(int, SoundQueueCount, 0x3B29B7C);

--- a/SADXModLoader/testspawn.cpp
+++ b/SADXModLoader/testspawn.cpp
@@ -1,0 +1,198 @@
+#include "stdafx.h"
+#include <ShellAPI.h>
+#include <string>
+#include <unordered_map>
+
+static const auto loc_40C318 = reinterpret_cast<const void*>(0x0040C318);
+
+__declspec(naked) void ForceTrialMode()
+{
+	__asm
+	{
+		mov GameMode, GameModes_Trial
+		jmp loc_40C318
+	}
+}
+
+static const std::unordered_map<std::wstring, uint8_t> level_name_ids_map = {
+	{ L"hedgehoghammer",    LevelIDs_HedgehogHammer },
+	{ L"emeraldcoast",      LevelIDs_EmeraldCoast },
+	{ L"windyvalley",       LevelIDs_WindyValley },
+	{ L"twinklepark",       LevelIDs_TwinklePark },
+	{ L"speedhighway",      LevelIDs_SpeedHighway },
+	{ L"redmountain",       LevelIDs_RedMountain },
+	{ L"skydeck",           LevelIDs_SkyDeck },
+	{ L"lostworld",         LevelIDs_LostWorld },
+	{ L"icecap",            LevelIDs_IceCap },
+	{ L"casinopolis",       LevelIDs_Casinopolis },
+	{ L"finalegg",          LevelIDs_FinalEgg },
+	{ L"hotshelter",        LevelIDs_HotShelter },
+	{ L"chaos0",            LevelIDs_Chaos0 },
+	{ L"chaos2",            LevelIDs_Chaos2 },
+	{ L"chaos4",            LevelIDs_Chaos4 },
+	{ L"chaos6",            LevelIDs_Chaos6 },
+	{ L"perfectchaos",      LevelIDs_PerfectChaos },
+	{ L"egghornet",         LevelIDs_EggHornet },
+	{ L"eggwalker",         LevelIDs_EggWalker },
+	{ L"eggviper",          LevelIDs_EggViper },
+	{ L"zero",              LevelIDs_Zero },
+	{ L"e101",              LevelIDs_E101 },
+	{ L"e101r",             LevelIDs_E101R },
+	{ L"stationsquare",     LevelIDs_StationSquare },
+	{ L"eggcarrieroutside", LevelIDs_EggCarrierOutside },
+	{ L"eggcarrierinside",  LevelIDs_EggCarrierInside },
+	{ L"mysticruins",       LevelIDs_MysticRuins },
+	{ L"past",              LevelIDs_Past },
+	{ L"twinklecircuit",    LevelIDs_TwinkleCircuit },
+	{ L"skychase1",         LevelIDs_SkyChase1 },
+	{ L"skychase2",         LevelIDs_SkyChase2 },
+	{ L"sandhill",          LevelIDs_SandHill },
+	{ L"ssgarden",          LevelIDs_SSGarden },
+	{ L"ecgarden",          LevelIDs_ECGarden },
+	{ L"mrgarden",          LevelIDs_MRGarden },
+	{ L"chaorace",          LevelIDs_ChaoRace }
+};
+
+static uint8_t parse_level_id(const std::wstring& str)
+{
+	std::wstring lowercase = str;
+	std::transform(lowercase.begin(), lowercase.end(), lowercase.begin(), ::towlower);
+
+	const auto it = level_name_ids_map.find(lowercase);
+
+	if (it != level_name_ids_map.end())
+		return it->second;
+
+	return static_cast<uint8_t>(std::stol(lowercase));
+}
+
+static const std::unordered_map<std::wstring, uint8_t> character_name_ids_map = {
+	{ L"sonic",      Characters_Sonic },
+	{ L"eggman",     Characters_Eggman },
+	{ L"tails",      Characters_Tails },
+	{ L"knuckles",   Characters_Knuckles },
+	{ L"tikal",      Characters_Tikal },
+	{ L"amy",        Characters_Amy },
+	{ L"gamma",      Characters_Gamma },
+	{ L"big",        Characters_Big },
+	{ L"metalsonic", Characters_MetalSonic }
+};
+
+static uint8_t parse_character_id(const std::wstring& str)
+{
+	std::wstring lowercase = str;
+	transform(lowercase.begin(), lowercase.end(), lowercase.begin(), ::towlower);
+
+	const auto it = character_name_ids_map.find(lowercase);
+
+	if (it != character_name_ids_map.end())
+		return it->second;
+
+	return static_cast<uint8_t>(std::stol(lowercase));
+}
+
+static void Obj_Icecap_r(ObjectMaster* o)
+{
+	if (o)
+	{
+		MovePlayerToStartPoint(EntityData1Ptrs[0]);
+		o->MainSub = Obj_Icecap;
+		Obj_Icecap(o);
+	}
+}
+
+void TestSpawnCheckArgs(const HelperFunctions& helperFunctions)
+{
+	int argc = 0;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+
+	bool level_set = false;
+	bool act_set = false;
+
+	// NOP. Prevents CurrentCharacter from being overwritten. There could be other side
+	// effects, but there are none that we've noticed thus far.
+	WriteData<5>(reinterpret_cast<void*>(0x00415007), 0x90u);
+
+	for (int i = 1; i < argc; i++)
+	{
+		if (!wcscmp(argv[i], L"--level") || !wcscmp(argv[i], L"-l"))
+		{
+			CurrentLevel = parse_level_id(argv[++i]);
+			PrintDebug("Loading level: %d\n", CurrentLevel);
+			level_set = true;
+		}
+		else if (!wcscmp(argv[i], L"--act") || !wcscmp(argv[i], L"-a"))
+		{
+			CurrentAct = _wtoi(argv[++i]);
+			PrintDebug("Loading act: %d\n", CurrentAct);
+			act_set = true;
+		}
+		else if (!wcscmp(argv[i], L"--character") || !wcscmp(argv[i], L"-c"))
+		{
+			uint8_t character_id = parse_character_id(argv[++i]);
+
+			if (character_id == Characters_MetalSonic)
+			{
+				MetalSonicFlag = 1;
+				character_id = 0;
+			}
+
+			CurrentCharacter = character_id;
+			PrintDebug("Loading character: %d\n", CurrentCharacter);
+		}
+		else if (!wcscmp(argv[i], L"--position") || !wcscmp(argv[i], L"-p"))
+		{
+			if (!level_set && !act_set)
+			{
+				MessageBoxA(nullptr, "Insufficient arguments for parameter: --position.\n"
+					"Either --level or --act must be specified before --position.",
+					"Insufficient arguments", MB_OK);
+
+				continue;
+			}
+
+			if (i + 3 >= argc)
+			{
+				MessageBoxA(nullptr, "Insufficient arguments for parameter: --position.\n"
+					"All 3 components (X, Y, Z) of the spawn position must be provided. Default spawn point will be used.",
+					"Insufficient arguments", MB_OK);
+
+				continue;
+			}
+
+			if (CurrentLevel == LevelIDs_IceCap)
+			{
+				// NOPs to disable several checks for LevelIDs_IceCap which prevent
+				// correct player positioning and orienting.
+				WriteData<2>(reinterpret_cast<void*>(0x004149EC), 0x90u);
+				WriteData<2>(reinterpret_cast<void*>(0x0041497F), 0x90u);
+				WriteData<2>(reinterpret_cast<void*>(0x00414A70), 0x90u);
+
+				using LevelObjectFunc = void(__cdecl*)(ObjectMaster* this_);
+				LevelObjects[LevelIDs_IceCap] = Obj_Icecap_r;
+			}
+
+			const float x = std::stof(argv[++i]);
+			const float y = std::stof(argv[++i]);
+			const float z = std::stof(argv[++i]);
+
+			StartPosition position = {
+				CurrentLevel,
+				static_cast<int16_t>(CurrentAct),
+				// Position
+				{ x, y, z },
+				// YRot
+				0
+			};
+
+			helperFunctions.RegisterStartPosition(static_cast<Uint8>(CurrentCharacter), position);
+		}
+	}
+
+	if (level_set || act_set)
+	{
+		WriteJump(reinterpret_cast<void*>(0x0040C115), ForceTrialMode);
+	}
+
+	LocalFree(argv);
+}

--- a/SADXModLoader/testspawn.cpp
+++ b/SADXModLoader/testspawn.cpp
@@ -134,6 +134,22 @@ static void Obj_Icecap_r(ObjectMaster* o)
 	}
 }
 
+static void DisableMusic()
+{
+	Music_Enabled = false;
+}
+
+static void DisableVoice()
+{	
+	EnableVoice = false;
+}
+
+static void DisableSound()
+{
+	// RET. Prevents the SoundQueue from running.
+	WriteData<1>(reinterpret_cast<void*>(0x004250D0), 0xC3);
+}
+
 void TestSpawnCheckArgs(const HelperFunctions& helperFunctions)
 {
 	int argc = 0;
@@ -220,6 +236,24 @@ void TestSpawnCheckArgs(const HelperFunctions& helperFunctions)
 			};
 
 			helperFunctions.RegisterStartPosition(static_cast<Uint8>(CurrentCharacter), position);
+		}
+		else if (!wcscmp(argv[i], L"--no-music"))
+		{
+			DisableMusic();
+		}
+		else if (!wcscmp(argv[i], L"--no-voice"))
+		{
+			DisableVoice();
+		}
+		else if (!wcscmp(argv[i], L"--no-sound"))
+		{
+			DisableSound();
+		}
+		else if (!wcscmp(argv[i], L"--no-audio"))
+		{
+			DisableMusic();
+			DisableVoice();
+			DisableSound();
 		}
 	}
 

--- a/SADXModLoader/testspawn.h
+++ b/SADXModLoader/testspawn.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void TestSpawnCheckArgs(const HelperFunctions& helperFunctions);


### PR DESCRIPTION
This PR brings the [TestSpawn](https://github.com/sonicretro/sadx-test-spawn) mod by @michael-fadely directly into the Mod Loader.

Additions:
- `--save` command to load a specific save file. Usage: `--save 12`.
- `--no-music`, `--no-voice`, `--no-sound` and `no-audio` commands as suggested [here](https://github.com/sonicretro/sadx-test-spawn/issues/2).