### PR TITLE
Integrate the Sky Chase fix

### DIFF
--- a/SADXModLoader/SADXModLoader.vcxproj
+++ b/SADXModLoader/SADXModLoader.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="prs.cpp" />
     <ClCompile Include="MediaFns.cpp" />
     <ClCompile Include="pvmx.cpp" />
+    <ClCompile Include="SkyChaseFixes.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -69,6 +70,7 @@
     <ClInclude Include="include\SADXVariables.h" />
     <ClInclude Include="MediaFns.hpp" />
     <ClInclude Include="pvmx.h" />
+    <ClInclude Include="SkyChaseFixes.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="testspawn.h" />
     <ClInclude Include="TextureReplacement.h" />

--- a/SADXModLoader/SADXModLoader.vcxproj.filters
+++ b/SADXModLoader/SADXModLoader.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="CrashDump.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="SkyChaseFixes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MediaFns.hpp">
@@ -195,6 +198,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CrashDump.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SkyChaseFixes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SADXModLoader/SkyChaseFixes.cpp
+++ b/SADXModLoader/SkyChaseFixes.cpp
@@ -1,0 +1,140 @@
+#include "stdafx.h"
+#include <SADXModLoader.h>
+#include "SkyChaseFixes.h"
+
+static float HorizontalResolution_float = 640.0f;
+static float VerticalResolution_float = 480.0f;
+static float VerticalResolutionHalf_float = 240.0f;
+
+static float float_one = 1.0f;
+static float tornado_speed = 1.0f;
+static float target_collision_size = 1.0f;
+static float target_speed_multiplier = 2.0f;
+
+static double SkyChaseSkyRotationMultiplier = -0.5f;
+
+static const int  hack_int = 0x39A1877F;
+static const auto hack_flt = *reinterpret_cast<const float*>(&hack_int);
+
+template <typename T>
+T clamp(T value, T low, T high)
+{
+	if (value < low)
+	{
+		return low;
+	}
+
+	if (value > high)
+	{
+		return high;
+	}
+
+	return value;
+}
+
+static void TornadoTarget_MoveTargetWithinBounds_asm();
+static void __cdecl TornadoTarget_CalculateCenterPoint_r(ObjectMaster* a1);
+static void __cdecl TornadoFixTargetSpriteScale(NJS_SPRITE* sp, Int n, Float pri, NJD_SPRITE attr);
+
+void SkyChaseFix_UpdateBounds()
+{
+	// Resolution related fixes
+	HorizontalResolution_float = static_cast<float>(HorizontalResolution);
+	VerticalResolution_float = static_cast<float>(VerticalResolution);
+	VerticalResolutionHalf_float = VerticalResolution_float / 2.0f;
+
+	auto m = min(VerticalStretch, HorizontalStretch);
+
+	// Sky Chase reticle and multiplier fixes
+	target_speed_multiplier = m;
+	target_collision_size = 1024.0f * m;
+
+	WriteData(reinterpret_cast<float*>(0x00628951), m); // Reticle scale X
+	WriteData(reinterpret_cast<float*>(0x0062895B), m); // Reticle scale Y
+}
+
+void SkyChaseFix_Init()
+{
+	SkyChaseFix_UpdateBounds();
+
+	WriteJump(reinterpret_cast<void*>(0x00628970), TornadoTarget_MoveTargetWithinBounds_asm);
+
+	WriteData(reinterpret_cast<float**>(0x00627F4D), &tornado_speed); // Tornado Speed (always 1)
+	WriteData(reinterpret_cast<float**>(0x00627F60), &float_one);     // Horizontal limit
+	WriteData(reinterpret_cast<float**>(0x00627F72), &float_one);     // Vertical limit
+
+	WriteJump(reinterpret_cast<void*>(0x628D50), TornadoTarget_CalculateCenterPoint_r); // Calculate center for bullets
+
+	// Hodai fixes
+	WriteData(reinterpret_cast<float**>(0x0043854D), &HorizontalResolution_float);
+	WriteData(reinterpret_cast<float**>(0x00438571), &VerticalResolutionHalf_float);
+	WriteData(reinterpret_cast<float**>(0x0043857F), &VerticalResolutionHalf_float);
+
+	WriteData(reinterpret_cast<float**>(0x628AF7), &target_collision_size);     // Target size
+	WriteData(reinterpret_cast<float**>(0x00629472), &target_speed_multiplier); // Target speed
+
+	// Visual stuff
+	WriteData(reinterpret_cast<double**>(0x00627D14), &SkyChaseSkyRotationMultiplier);
+	WriteCall(reinterpret_cast<void*>(0x00628E4D), TornadoFixTargetSpriteScale);
+}
+
+static void __cdecl TornadoTarget_MoveTargetWithinBounds_r(ObjectMaster* a1)
+{
+	EntityData1* data1 = a1->Data1;
+
+	const float m = min(VerticalStretch, HorizontalStretch);
+	const float move_speed = m * hack_flt;
+
+	// 640x480 - 160x160 margin
+	const auto w = 480.0f * m;
+	const auto h = 320.0f * m;
+
+	float x = (static_cast<float>(static_cast<int>(Controllers[0].LeftStickX) << 8) * move_speed) + data1->Position.x;
+	float y = (static_cast<float>(static_cast<int>(Controllers[0].LeftStickY) << 8) * move_speed) + data1->Position.y;
+
+	const float left = (HorizontalResolution_float - w) / 2.0f;
+	const float top = (VerticalResolution_float - h) / 2.0f;
+	const float right = left + w;
+	const float bottom = top + h;
+
+	x = clamp(x, left, right);
+	y = clamp(y, top, bottom);
+
+	data1->Position.x = x;
+	data1->Position.y = y;
+}
+
+static void __declspec(naked) TornadoTarget_MoveTargetWithinBounds_asm()
+{
+	__asm
+	{
+		push eax
+		call TornadoTarget_MoveTargetWithinBounds_r
+		pop eax
+		retn
+	}
+}
+
+static void __cdecl TornadoTarget_CalculateCenterPoint_r(ObjectMaster* a1)
+{
+	EntityData1* parent_data1 = a1->Parent->Data1;
+	NJS_VECTOR* position = &a1->Data1->Position;
+
+	position->x = parent_data1->Position.x - _nj_screen_.cx;
+	position->y = parent_data1->Position.y - _nj_screen_.cy;
+	position->z = 1000.0f * min(VerticalStretch, HorizontalStretch);
+
+	njPushMatrix(nullptr);
+	njInvertMatrix(nullptr);
+	njCalcPoint(nullptr, position, position);
+	njPopMatrix(1u);
+}
+
+static void __cdecl TornadoFixTargetSpriteScale(NJS_SPRITE* sp, Int n, Float pri, NJD_SPRITE attr)
+{
+	if (!IsGamePaused())
+	{
+		sp->sy = sp->sy * min(VerticalStretch, HorizontalStretch);
+		njDrawSprite2D_ForcePriority(sp, n, pri, attr);
+	}
+}

--- a/SADXModLoader/SkyChaseFixes.cpp
+++ b/SADXModLoader/SkyChaseFixes.cpp
@@ -6,15 +6,11 @@ static float HorizontalResolution_float = 640.0f;
 static float VerticalResolution_float = 480.0f;
 static float VerticalResolutionHalf_float = 240.0f;
 
-static float float_one = 1.0f;
-static float tornado_speed = 1.0f;
+static const float float_one = 1.0f;
 static float target_collision_size = 1.0f;
 static float target_speed_multiplier = 2.0f;
 
-static double SkyChaseSkyRotationMultiplier = -0.5f;
-
-static const int  hack_int = 0x39A1877F;
-static const auto hack_flt = *reinterpret_cast<const float*>(&hack_int);
+static const double SkyRotationMultiplier = -0.5;
 
 template <typename T>
 T clamp(T value, T low, T high)
@@ -32,9 +28,63 @@ T clamp(T value, T low, T high)
 	return value;
 }
 
-static void TornadoTarget_MoveTargetWithinBounds_asm();
-static void __cdecl TornadoTarget_CalculateCenterPoint_r(ObjectMaster* a1);
-static void __cdecl TornadoFixTargetSpriteScale(NJS_SPRITE* sp, Int n, Float pri, NJD_SPRITE attr);
+static void __cdecl TornadoTarget_MoveTargetWithinBounds_r(task* tp)
+{
+	auto pos = &tp->twp->pos;
+
+	const float m = min(VerticalStretch, HorizontalStretch);
+	const float move_speed = m * 0.000308093f;
+
+	// 640x480 - 160x160 margin
+	const float w = 480.0f * m;
+	const float h = 320.0f * m;
+
+	const float left = (HorizontalResolution_float - w) / 2.0f;
+	const float top = (VerticalResolution_float - h) / 2.0f;
+	const float right = left + w;
+	const float bottom = top + h;
+
+	const float x = (static_cast<float>(static_cast<int>(Controllers[0].LeftStickX) << 8) * move_speed) + pos->x;
+	const float y = (static_cast<float>(static_cast<int>(Controllers[0].LeftStickY) << 8) * move_speed) + pos->y;
+
+	pos->x = clamp(x, left, right);
+	pos->y = clamp(y, top, bottom);
+}
+
+static void __declspec(naked) TornadoTarget_MoveTargetWithinBounds_asm()
+{
+	__asm
+	{
+		push eax
+		call TornadoTarget_MoveTargetWithinBounds_r
+		pop eax
+		retn
+	}
+}
+
+static void __cdecl TornadoTarget_CalculateCenterPoint_r(task* tp)
+{
+	auto pos = &tp->twp->pos;
+	auto parent_pos = &tp->ptp->twp->pos;
+
+	pos->x = parent_pos->x - _nj_screen_.cx;
+	pos->y = parent_pos->y - _nj_screen_.cy;
+	pos->z = 1000.0f * min(VerticalStretch, HorizontalStretch);
+
+	njPushMatrix(nullptr);
+	njInvertMatrix(nullptr);
+	njCalcPoint(nullptr, pos, pos);
+	njPopMatrixEx();
+}
+
+static void __cdecl TornadoFixTargetSpriteScale(NJS_SPRITE* sp, Int n, Float pri, NJD_SPRITE attr)
+{
+	if (!IsGamePaused())
+	{
+		sp->sy = sp->sy * min(VerticalStretch, HorizontalStretch);
+		njDrawSprite2D_ForcePriority(sp, n, pri, attr);
+	}
+}
 
 void SkyChaseFix_UpdateBounds()
 {
@@ -59,9 +109,9 @@ void SkyChaseFix_Init()
 
 	WriteJump(reinterpret_cast<void*>(0x00628970), TornadoTarget_MoveTargetWithinBounds_asm);
 
-	WriteData(reinterpret_cast<float**>(0x00627F4D), &tornado_speed); // Tornado Speed (always 1)
-	WriteData(reinterpret_cast<float**>(0x00627F60), &float_one);     // Horizontal limit
-	WriteData(reinterpret_cast<float**>(0x00627F72), &float_one);     // Vertical limit
+	WriteData(reinterpret_cast<const float**>(0x00627F4D), &float_one); // Tornado Speed (always 1)
+	WriteData(reinterpret_cast<const float**>(0x00627F60), &float_one); // Horizontal limit
+	WriteData(reinterpret_cast<const float**>(0x00627F72), &float_one); // Vertical limit
 
 	WriteJump(reinterpret_cast<void*>(0x628D50), TornadoTarget_CalculateCenterPoint_r); // Calculate center for bullets
 
@@ -74,67 +124,6 @@ void SkyChaseFix_Init()
 	WriteData(reinterpret_cast<float**>(0x00629472), &target_speed_multiplier); // Target speed
 
 	// Visual stuff
-	WriteData(reinterpret_cast<double**>(0x00627D14), &SkyChaseSkyRotationMultiplier);
+	WriteData(reinterpret_cast<const double**>(0x00627D14), &SkyRotationMultiplier);
 	WriteCall(reinterpret_cast<void*>(0x00628E4D), TornadoFixTargetSpriteScale);
-}
-
-static void __cdecl TornadoTarget_MoveTargetWithinBounds_r(ObjectMaster* a1)
-{
-	EntityData1* data1 = a1->Data1;
-
-	const float m = min(VerticalStretch, HorizontalStretch);
-	const float move_speed = m * hack_flt;
-
-	// 640x480 - 160x160 margin
-	const auto w = 480.0f * m;
-	const auto h = 320.0f * m;
-
-	float x = (static_cast<float>(static_cast<int>(Controllers[0].LeftStickX) << 8) * move_speed) + data1->Position.x;
-	float y = (static_cast<float>(static_cast<int>(Controllers[0].LeftStickY) << 8) * move_speed) + data1->Position.y;
-
-	const float left = (HorizontalResolution_float - w) / 2.0f;
-	const float top = (VerticalResolution_float - h) / 2.0f;
-	const float right = left + w;
-	const float bottom = top + h;
-
-	x = clamp(x, left, right);
-	y = clamp(y, top, bottom);
-
-	data1->Position.x = x;
-	data1->Position.y = y;
-}
-
-static void __declspec(naked) TornadoTarget_MoveTargetWithinBounds_asm()
-{
-	__asm
-	{
-		push eax
-		call TornadoTarget_MoveTargetWithinBounds_r
-		pop eax
-		retn
-	}
-}
-
-static void __cdecl TornadoTarget_CalculateCenterPoint_r(ObjectMaster* a1)
-{
-	EntityData1* parent_data1 = a1->Parent->Data1;
-	NJS_VECTOR* position = &a1->Data1->Position;
-
-	position->x = parent_data1->Position.x - _nj_screen_.cx;
-	position->y = parent_data1->Position.y - _nj_screen_.cy;
-	position->z = 1000.0f * min(VerticalStretch, HorizontalStretch);
-
-	njPushMatrix(nullptr);
-	njInvertMatrix(nullptr);
-	njCalcPoint(nullptr, position, position);
-	njPopMatrix(1u);
-}
-
-static void __cdecl TornadoFixTargetSpriteScale(NJS_SPRITE* sp, Int n, Float pri, NJD_SPRITE attr)
-{
-	if (!IsGamePaused())
-	{
-		sp->sy = sp->sy * min(VerticalStretch, HorizontalStretch);
-		njDrawSprite2D_ForcePriority(sp, n, pri, attr);
-	}
 }

--- a/SADXModLoader/SkyChaseFixes.h
+++ b/SADXModLoader/SkyChaseFixes.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void SkyChaseFix_UpdateBounds();
+void SkyChaseFix_Init();

--- a/SADXModLoader/hudscale.cpp
+++ b/SADXModLoader/hudscale.cpp
@@ -2,6 +2,7 @@
 #include "Trampoline.h"
 #include "uiscale.h"
 #include "hudscale.h"
+#include "SkyChaseFixes.h"
 
 using namespace uiscale;
 
@@ -1015,6 +1016,9 @@ void hudscale::update()
 	// Black Market Item Preview
 	WriteData(reinterpret_cast<float*>(0x00726211), preview_animal_hat_shell);
 	WriteData(reinterpret_cast<float*>(0x007261CF), preview_pacifier);
+
+	// Sky Chase
+	SkyChaseFix_UpdateBounds();
 }
 
 static void InitializeChaoHUDs()
@@ -1173,6 +1177,9 @@ void hudscale::initialize()
 	scaleTailsRaceBar                    = new Trampoline(0x0047C260, 0x0047C267, ScaleTailsRaceBar);
 	scaleDemoPressStart                  = new Trampoline(0x00457D30, 0x00457D36, ScaleDemoPressStart);
 	late_exec_t                          = new Trampoline(0x004086F0, 0x004086F6, late_exec_r); // Sometimes used in a display function so we have to disable scaling temporarily
+
+	// Sky Chase reticle and score calculation
+	SkyChaseFix_Init();
 
 	// Big UI
 	WriteData(reinterpret_cast<const float**>(0x0047024E), &patch_dummy);


### PR DESCRIPTION
The Sky Chase fix originally developed for Dreamcast Conversion and SADXFE changes Sky Chase control sensitivity, enemy detection range, reticle scale and score calculation at different resolutions to behave more like they would at the game's original resolution of 640x480. This is a "lite" version of the fix that makes only the minimum required changes and doesn't touch other things such as lighting or the skybox. Only one drawing function call was hooked to fix the scale of the locked-on reticle.

The fix is compatible with the versions of it included in SADXFE and Dreamcast Conversion. As it is added as part of the UI Scaling option, it can be disabled using the "UI Scaling" toggle.