### PR TITLE
Support For Individual Texture Replacements

### DIFF
--- a/SADXModLoader/TextureReplacement.cpp
+++ b/SADXModLoader/TextureReplacement.cpp
@@ -40,8 +40,15 @@ static const unordered_map<HRESULT, const char*> D3D_ERRORS = {
 	TOMAPSTRING(E_OUTOFMEMORY)
 };
 
+struct TexReplaceData : TexPackEntry
+{
+	int mod_index;
+	string path;
+};
+
 static unordered_map<string, vector<TexPackEntry>> raw_cache;
 static unordered_map<string, vector<pvmx::DictionaryEntry>> archive_cache;
+static unordered_map<string, unordered_map<string, TexReplaceData>*> replace_cache;
 static bool was_loading = false;
 
 DataArray(NJS_TEXPALETTE*, unk_3CFC000, 0x3CFC000, 0);
@@ -63,6 +70,71 @@ void texpack::init()
 	WriteJump(static_cast<void*>(LoadPvmMEM2), LoadPvmMEM2_r);
 	WriteJump(static_cast<void*>(njLoadTexturePvmFile), njLoadTexturePvmFile_r);
 }
+
+void ScanTextureReplaceFolder(const string& srcPath, int modIndex)
+{
+	WIN32_FIND_DATAA data;
+	char path[MAX_PATH];
+	snprintf(path, sizeof(path), "%s\\*", srcPath.c_str());
+	auto hFind = FindFirstFileA(path, &data);
+
+	string lower = srcPath;
+	transform(lower.begin(), lower.end(), lower.begin(), tolower);
+
+	// No files found.
+	if (hFind == INVALID_HANDLE_VALUE)
+	{
+		return;
+	}
+
+	do
+	{
+		// NOTE: This will hide *all* files starting with '.'.
+		// SADX doesn't use any files starting with '.',
+		// so this won't cause any problems.
+		if (data.cFileName[0] == '.')
+		{
+			continue;
+		}
+
+		const string fileName = string(data.cFileName);
+
+		if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+		{
+			string original = fileName;
+			transform(original.begin(), original.end(), original.begin(), ::tolower);
+
+			string texPack = srcPath + '\\' + fileName;
+			transform(texPack.begin(), texPack.end(), texPack.begin(), ::tolower);
+
+			// Since we don't attempt to parse this file, make sure it exists
+			// before registering an empty texture pack directory.
+			vector<TexPackEntry> index;
+			if (texpack::parse_index(texPack, index))
+			{
+				unordered_map<string, TexReplaceData>* pvmdata;
+				auto& iter = replace_cache.find(original);
+				if (iter == replace_cache.end())
+				{
+					pvmdata = new unordered_map<string, TexReplaceData>;
+					replace_cache.insert({ original, pvmdata });
+				}
+				else
+					pvmdata = iter->second;
+				for (const auto& idx : index)
+				{
+					string nameNoExt = idx.name;
+					StripExtension(nameNoExt);
+					transform(nameNoExt.begin(), nameNoExt.end(), nameNoExt.begin(), tolower);
+					(*pvmdata)[nameNoExt] = { idx.global_index, idx.name, idx.width, idx.height, modIndex, texPack };
+				}
+			}
+		}
+	} while (FindNextFileA(hFind, &data) != 0);
+
+	FindClose(hFind);
+}
+
 
 inline void check_loading()
 {
@@ -565,9 +637,31 @@ static bool replace_pvm(const string& path, NJS_TEXLIST* texlist)
 
 	dynamic_expand(texlist, index.size());
 
+	transform(pvm_name.begin(), pvm_name.end(), pvm_name.begin(), ::tolower);
+
+	const unordered_map<string, TexReplaceData>* replacements = nullptr;
+	const auto& repiter = replace_cache.find(pvm_name);
+	if (repiter != replace_cache.cend())
+		replacements = repiter->second;
+
+	string pvm_path = "system\\" + pvm_name + ".pvm";
+	int modIdx = sadx_fileMap.getModIndex(pvm_path.c_str());
+
 	for (uint32_t i = 0; i < texlist->nbTexture; i++)
 	{
-		auto texture = load_texture(path, index[i], mipmap);
+		NJS_TEXMEMLIST* texture = nullptr;
+		if (replacements)
+		{
+			auto lower = index[i].name;
+			StripExtension(lower);
+			transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+			const auto& iter2 = replacements->find(lower);
+			if (iter2 != replacements->cend() && iter2->second.mod_index >= modIdx)
+				texture = load_texture(iter2->second.path, iter2->second, mipmap);
+		}
+
+		if (!texture)
+			texture = load_texture(path, index[i], mipmap);
 
 		if (texture == nullptr)
 		{
@@ -613,12 +707,34 @@ static bool replace_pvmx(const string& path, ifstream& file, NJS_TEXLIST* texlis
 
 	dynamic_expand(texlist, index.size());
 
+	transform(pvm_name.begin(), pvm_name.end(), pvm_name.begin(), ::tolower);
+
+	const unordered_map<string, TexReplaceData>* replacements = nullptr;
+	const auto& repiter = replace_cache.find(pvm_name);
+	if (repiter != replace_cache.cend())
+		replacements = repiter->second;
+
+	string pvm_path = "system\\" + pvm_name + ".pvm";
+	int modIdx = sadx_fileMap.getModIndex(pvm_path.c_str());
+
 	for (size_t i = 0; i < index.size(); i++)
 	{
 		auto& entry = index[i];
 
-		auto texture = load_texture_stream(file, entry.offset, entry.size,
-		                                   path, entry.global_index, entry.name, mipmap, entry.width, entry.height);
+		NJS_TEXMEMLIST* texture = nullptr;
+		if (replacements)
+		{
+			auto lower = entry.name;
+			StripExtension(lower);
+			transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+			const auto& iter2 = replacements->find(lower);
+			if (iter2 != replacements->cend() && iter2->second.mod_index >= modIdx)
+				texture = load_texture(iter2->second.path, iter2->second, mipmap);
+		}
+
+		if (!texture)
+			texture = load_texture_stream(file, entry.offset, entry.size,
+			                              path, entry.global_index, entry.name, mipmap, entry.width, entry.height);
 
 		if (texture == nullptr)
 		{

--- a/SADXModLoader/TextureReplacement.cpp
+++ b/SADXModLoader/TextureReplacement.cpp
@@ -73,6 +73,8 @@ void texpack::init()
 
 void ScanTextureReplaceFolder(const string& srcPath, int modIndex)
 {
+	if (srcPath.size() > MAX_PATH - 3)
+		return;
 	WIN32_FIND_DATAA data;
 	char path[MAX_PATH];
 	snprintf(path, sizeof(path), "%s\\*", srcPath.c_str());

--- a/SADXModLoader/TextureReplacement.h
+++ b/SADXModLoader/TextureReplacement.h
@@ -10,6 +10,7 @@ struct TexPackEntry
 };
 
 void ScanTextureReplaceFolder(const std::string& srcPath, int modIndex);
+void ReplaceTexture(const char* pvm_name, const char* tex_name, const char* file_path, uint32_t gbix, uint32_t width, uint32_t height);
 
 namespace texpack
 {

--- a/SADXModLoader/TextureReplacement.h
+++ b/SADXModLoader/TextureReplacement.h
@@ -9,6 +9,8 @@ struct TexPackEntry
 	uint32_t width, height;
 };
 
+void ScanTextureReplaceFolder(const std::string& srcPath, int modIndex);
+
 namespace texpack
 {
 	/**

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1310,7 +1310,8 @@ static const HelperFunctions helperFunctions =
 	&PushScaleUI,
 	&PopScaleUI,
 	&SetScaleFillMode,
-	&GetScaleFillMode
+	&GetScaleFillMode,
+	&ReplaceTexture
 };
 
 static const char* const dlldatakeys[] = {

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1743,6 +1743,10 @@ static void __cdecl InitMods()
 		if (DirectoryExists(modTexDir))
 			sadx_fileMap.scanTextureFolder(modTexDir, i);
 
+		const string modRepTexDir = mod_dirA + "\\replacetex";
+		if (DirectoryExists(modRepTexDir))
+			ScanTextureReplaceFolder(modRepTexDir, i);
+
 		// Check if a custom EXE is required.
 		if (modinfo->hasKeyNonEmpty("EXEFile"))
 		{

--- a/SADXModLoader/include/SADXModInfo.h
+++ b/SADXModLoader/include/SADXModInfo.h
@@ -11,7 +11,7 @@
 #include "ScaleInfo.h"
 
 // SADX Mod Loader API version.
-static const int ModLoaderVer = 11;
+static const int ModLoaderVer = 12;
 
 struct PatchInfo
 {
@@ -146,6 +146,10 @@ struct HelperFunctions
 	// Returns the current filling method for background sprites.
 	// Requires version >= 11.
 	uiscale::FillMode(__cdecl* GetScaleFillMode)();
+
+	// Replaces an individual texture from a PVM file with an image file.
+	// Requires version >= 12.
+	void(__cdecl* ReplaceTexture)(const char* pvm_name, const char* tex_name, const char* file_path, uint32_t gbix, uint32_t width, uint32_t height);
 };
 
 typedef void(__cdecl *ModInitFunc)(const char *path, const HelperFunctions &helperFunctions);


### PR DESCRIPTION
This will allow users to place texture packs in their mods in a `replacetex` folder that will enable them to override individual textures in any PVM/Texture Pack/PVMX file that comes before it in the mod order.

There is a slight issue where files that were renamed from the base game files and use the .pvm.prs extension (such as Dreamcast Conversion's textures) won't correctly report the mod index, thus always being replaced, but that mod's usually pretty early in the mod order anyway.