### PR TITLE
Fix polybuff performance when window resize is enabled

### DIFF
--- a/SADXModLoader/direct3d.cpp
+++ b/SADXModLoader/direct3d.cpp
@@ -93,6 +93,8 @@ static const D3DRENDERSTATETYPE D3DRENDERSTATE_TYPES[] = {
 
 static HRESULT reset_parameters()
 {
+	FreePolyBuffers();
+
 	// Grab the current FOV before making any changes.
 	auto fov = fov::get_fov();
 
@@ -206,6 +208,8 @@ static HRESULT reset_parameters()
 
 	TransformAndViewportInvalid = 1;
 	Direct3D_SetViewportAndTransform();
+
+	InitPolyBuffers(polybuff::alignment_probably, polybuff::count, polybuff::ptr);
 
 	RaiseEvents(modRenderDeviceReset);
 

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -935,19 +935,6 @@ Bool __cdecl FixEKey(int i)
 	return IsFreeCameraAllowed() == TRUE && GetKey(i) == TRUE;
 }
 
-const auto loc_794566 = (void*)0x00794566;
-
-void __declspec(naked) PolyBuff_Init_FixVBuffParams()
-{
-	__asm
-	{
-		push D3DPOOL_MANAGED
-		push ecx
-		push D3DUSAGE_WRITEONLY
-		jmp loc_794566
-	}
-}
-
 void __cdecl Direct3D_TextureFilterPoint_ForceLinear()
 {
 	Direct3D_Device->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1245,8 +1245,6 @@ static void __cdecl InitMods()
 		WriteData((char*)0x007853F3, (char)D3DPOOL_MANAGED);
 		// MeshSetBuffer_CreateVertexBuffer: Remove D3DUSAGE_DYNAMIC
 		WriteData((short*)0x007853F6, (short)D3DUSAGE_WRITEONLY);
-		// PolyBuff_Init: Remove D3DUSAGE_DYNAMIC and set pool to D3DPOOL_MANAGED
-		WriteJump((void*)0x0079455F, PolyBuff_Init_FixVBuffParams);
 	}
 
 	pauseWhenInactive = loaderSettings.PauseWhenInactive;
@@ -1384,6 +1382,9 @@ static void __cdecl InitMods()
 		uiscale::fmv_fill = static_cast<uiscale::FillMode>(fmvFill);
 		uiscale::setup_fmv_scale();
 	}
+
+	// This is different from the rewrite portion of the polybuff namespace!
+	polybuff::init();
 
 	if (!loaderSettings.DisablePolyBuff)
 		polybuff::rewrite_init();

--- a/SADXModLoader/polybuff.cpp
+++ b/SADXModLoader/polybuff.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#include <Trampoline.h>
+#include <FunctionHook.h>
 
 #include "polybuff.h"
 
@@ -13,23 +13,21 @@ namespace polybuff
 
 namespace
 {
-	Trampoline* InitPolyBuffers_t = nullptr;
+	FunctionHook<void, int, int, void*> InitPolyBuffers_t(0x0078E720);
 
 	void __cdecl InitPolyBuffers_r(int alignment_probably, int count, void* ptr)
 	{
-		NonStaticFunctionPointer(void, original, (int alignment_probably, int count, void* ptr), InitPolyBuffers_t->Target());
-
 		polybuff::alignment_probably = alignment_probably;
 		polybuff::count = count;
 		polybuff::ptr = ptr;
 
-		original(alignment_probably, count, ptr);
+		InitPolyBuffers_t.Original(alignment_probably, count, ptr);
 	}
 }
 
 void polybuff::init()
 {
-	InitPolyBuffers_t = new Trampoline(0x0078E720, 0x0078E729, InitPolyBuffers_r);
+	InitPolyBuffers_t.Hook(InitPolyBuffers_r);
 }
 
 /*

--- a/SADXModLoader/polybuff.cpp
+++ b/SADXModLoader/polybuff.cpp
@@ -6,9 +6,9 @@
 
 namespace polybuff
 {
-	int alignment_probably;
-	int count;
-	void* ptr;
+	int alignment_probably = 0;
+	int count = 0;
+	void* ptr = nullptr;
 }
 
 namespace

--- a/SADXModLoader/polybuff.cpp
+++ b/SADXModLoader/polybuff.cpp
@@ -1,5 +1,36 @@
 #include "stdafx.h"
+
+#include <Trampoline.h>
+
 #include "polybuff.h"
+
+namespace polybuff
+{
+	int alignment_probably;
+	int count;
+	void* ptr;
+}
+
+namespace
+{
+	Trampoline* InitPolyBuffers_t = nullptr;
+
+	void __cdecl InitPolyBuffers_r(int alignment_probably, int count, void* ptr)
+	{
+		NonStaticFunctionPointer(void, original, (int alignment_probably, int count, void* ptr), InitPolyBuffers_t->Target());
+
+		polybuff::alignment_probably = alignment_probably;
+		polybuff::count = count;
+		polybuff::ptr = ptr;
+
+		original(alignment_probably, count, ptr);
+	}
+}
+
+void polybuff::init()
+{
+	InitPolyBuffers_t = new Trampoline(0x0078E720, 0x0078E729, InitPolyBuffers_r);
+}
 
 /*
  * Despite having designated polybuff drawing functions

--- a/SADXModLoader/polybuff.h
+++ b/SADXModLoader/polybuff.h
@@ -2,5 +2,12 @@
 
 namespace polybuff
 {
+	// These three variables are the parameters used to initialize the polybuff subsystem.
+	// Used to re-initialize when the device resets (window resize etc).
+	extern int alignment_probably;
+	extern int count;
+	extern void* ptr;
+
+	void init();
 	void rewrite_init();
 }


### PR DESCRIPTION
This PR reverts changes made to the memory pool and locking method used by the polybuff subsystem. When window resizing was implemented, they were changed in a ham-fisted manner (by me!) to use the managed memory pool before the polybuff system was fully reverse engineered. Now that the polybuff system is effectively completely known, it has become clear that these changes were unnecessary.

When a device reset occurs (window resize, fullscreen toggle, etc), the polybuff system is simply finalized and re-initialized with no adverse effects. Mods with large numbers of animated meshes (i.e. Beta Windy Valley) see significant performance gains with this change.