### PR TITLE
Add "Render Backend" config option, allow to load d3d8to9 without placing d3d8.dll in game directory

### DIFF
--- a/SADXModLoader/SADXModLoader.vcxproj
+++ b/SADXModLoader/SADXModLoader.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AutoMipmap.cpp" />
+    <ClCompile Include="backend.cpp" />
     <ClCompile Include="BasicWeights.cpp" />
     <ClCompile Include="bgscale.cpp" />
     <ClCompile Include="ChunkSpecularFix.cpp" />
@@ -67,6 +68,7 @@
     <ClInclude Include="ChunkSpecularFix.h" />
     <ClInclude Include="config.h" />
     <ClInclude Include="CrashDump.h" />
+    <ClInclude Include="backend.h" />
     <ClInclude Include="DDS.h" />
     <ClInclude Include="direct3d.h" />
     <ClInclude Include="DisableRoundedCorners.h" />

--- a/SADXModLoader/SADXModLoader.vcxproj.filters
+++ b/SADXModLoader/SADXModLoader.vcxproj.filters
@@ -177,6 +177,9 @@
     <ClCompile Include="uiscale.cpp">
       <Filter>Source Files\Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="backend.cpp">
+      <Filter>Source Files\Graphics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MediaFns.hpp">
@@ -390,6 +393,9 @@
       <Filter>Header Files\Graphics</Filter>
     </ClInclude>
     <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="backend.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SADXModLoader/backend.cpp
+++ b/SADXModLoader/backend.cpp
@@ -33,6 +33,7 @@ void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring ext
 	switch ((RenderBackend)mode)
 	{
 	case DirectX8:
+	default:
 		break;
 	case DirectX9:
 		wstring d3d8oldpath = gamePath + L"\\d3d8.dll";

--- a/SADXModLoader/backend.cpp
+++ b/SADXModLoader/backend.cpp
@@ -28,7 +28,7 @@ IDirect3D8* __stdcall CreateDirect3D8Hook(UINT SDKVersion)
 	return result;
 }
 
-static void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring extLibPath)
+void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring extLibPath)
 {
 	switch ((RenderBackend)mode)
 	{

--- a/SADXModLoader/backend.cpp
+++ b/SADXModLoader/backend.cpp
@@ -1,0 +1,66 @@
+#include "stdafx.h"
+#include "d3d8types.h"
+using std::wstring;
+
+enum RenderBackend: int
+{
+	DirectX8 = 0,
+	DirectX9 = 1,
+};
+
+IDirect3D8* __stdcall CreateDirect3D8Hook(UINT SDKVersion)
+{
+	HMODULE d3d8to9 = GetModuleHandle(L"d3d8m.dll");
+	if (!d3d8to9)
+		return 0;
+	typedef IDirect3D8* (WINAPI* Direct3DCreate8Ptr)(UINT);
+	Direct3DCreate8Ptr Direct3DCreate8Original = (Direct3DCreate8Ptr)GetProcAddress(d3d8to9, "Direct3DCreate8");
+	if (!Direct3DCreate8Original)
+		return 0;
+	IDirect3D8* result = Direct3DCreate8Original(SDKVersion);
+	if (!result)
+	{
+		PrintDebug("D3D8to9: Error creating Direct3D object: IDirect3D8 pointer is null \n");
+		MessageBox(nullptr, L"Error creating Direct3D object: IDirect3D8 pointer is null.", L"Direct3D Object Error", MB_OK | MB_ICONERROR);
+		OnExit(0, 0, 0);
+		ExitProcess(0);
+	}
+	return result;
+}
+
+static void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring extLibPath)
+{
+	switch ((RenderBackend)mode)
+	{
+	case DirectX8:
+		break;
+	case DirectX9:
+		wstring d3d8oldpath = gamePath + L"\\d3d8.dll";
+		if (FileExists(d3d8oldpath))
+		{
+			PrintDebug("D3D8to9: d3d8.dll found in game directory, aborting D3D8to9 hook\n");
+			return;
+		}
+
+		bool d3d8to9DLL = false; // Handle of the DLL
+		wstring fullPath = extLibPath + L"D3D8M\\d3d8m.dll"; // Path to the DLL
+
+		// Attempt to load the DLL
+		d3d8to9DLL = LoadLibraryEx(fullPath.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+
+		if (d3d8to9DLL)
+			PrintDebug("D3D8to9: Loaded d3d8to9 DLL\n");
+		else
+		{
+			int err = GetLastError();
+			PrintDebug("D3D8to9: Error loading D3D8to9 DLL %X (%d)\n", err, err);
+			MessageBox(nullptr, L"Error loading D3D8to9.\n\n"
+				L"Make sure the Mod Loader is installed properly.",
+				L"D3D8to9 Load Error", MB_OK | MB_ICONERROR);
+			return;
+		}
+		// Hook Direct3DCreate8
+		WriteJump((void*)0x007C235E, CreateDirect3D8Hook);
+		break;
+	}
+}

--- a/SADXModLoader/backend.h
+++ b/SADXModLoader/backend.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+
+static void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring extLibPath);

--- a/SADXModLoader/backend.h
+++ b/SADXModLoader/backend.h
@@ -1,4 +1,4 @@
 #pragma once
 #include <string>
 
-static void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring extLibPath);
+void __cdecl InitRenderBackend(int mode, std::wstring gamePath, std::wstring extLibPath);

--- a/SADXModLoader/config.cpp
+++ b/SADXModLoader/config.cpp
@@ -83,6 +83,7 @@ void LoadModLoaderSettings(LoaderSettings* loaderSettings, std::wstring appPath)
 		loaderSettings->ResizableWindow = json_graphics.value("EnableResizableWindow", true);
 		loaderSettings->BackgroundFillMode = json_graphics.value("FillModeBackground", 2);
 		loaderSettings->FmvFillMode = json_graphics.value("FillModeFMV", 1);
+		loaderSettings->RenderBackend = json_graphics.value("RenderBackend", 0);
 		// ModeTextureFiltering ?
 		// ModeUIFiltering ?
 		loaderSettings->ScaleHud = json_graphics.value("EnableUIScaling", true);

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -70,6 +70,7 @@ using json = nlohmann::json;
 #include "window.h"
 #include "XInputFix.h"
 #include "dpi.h"
+#include "backend.h"
 
 wstring borderimage = L"mods\\Border.png";
 HINSTANCE g_hinstDll = nullptr;
@@ -468,7 +469,7 @@ static void __cdecl InitAudio()
 
 		// Attempt to load the DLL
 		bassDLL = LoadLibraryEx(fullPath.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
-
+		
 		if (bassDLL)
 			PrintDebug("Loaded Bass DLLs dependencies\n");
 		else
@@ -914,6 +915,7 @@ static void __cdecl InitMods()
 	}
 
 	PatchWindow(loaderSettings); // override window creation function
+	InitRenderBackend(loaderSettings.RenderBackend, exepath, extLibPath);
 
 	// Other various settings
 	if (IsGamePatchEnabled("DisableCDCheck"))

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -253,8 +253,8 @@ static void __cdecl ProcessCodes()
 }
 
 //used to get external lib location and extra config
-std::wstring appPath;
-std::wstring extLibPath;
+std::wstring appPath; // "AppData\SAManager\" with trailing slash
+std::wstring extLibPath; // "AppData\SAManager\extlib\" with trailing slash
 
 void SetAppPathConfig(std::wstring gamepath)
 {
@@ -859,7 +859,7 @@ static void __cdecl InitMods()
 	// Get sonic.exe's path and filename.
 	wchar_t pathbuf[MAX_PATH];
 	GetModuleFileName(nullptr, pathbuf, MAX_PATH);
-	wstring exepath(pathbuf);
+	wstring exepath(pathbuf); // "C:\SADX" etc. without trailing slash
 	wstring exefilename;
 	string::size_type slash_pos = exepath.find_last_of(L"/\\");
 	if (slash_pos != string::npos)

--- a/SADXModLoader/include/SADXModInfo.h
+++ b/SADXModLoader/include/SADXModInfo.h
@@ -12,7 +12,7 @@
 #include "WeightInfo.h"
 
  // SADX Mod Loader API version.
-static const int ModLoaderVer = 26;
+static const int ModLoaderVer = 27;
 
 // Patch-type codes
 struct PatchInfo
@@ -106,6 +106,7 @@ struct LoaderSettings
 	bool DisableBorderImage; // Requires version >= 25
 	int Antialiasing; // Requires version >= 26
 	int Anisotropic; // Requires version >= 26
+	int RenderBackend; // Requires version >= 27
 };
 
 struct ModDependency


### PR DESCRIPTION
**Description**
This PR adds a `RenderBackend` (int) option to Graphics settings in the loader JSON file. The following values are usable at the moment:
0 - DirectX 8.1 (default)
1 - DirectX 9 via d3d8to9

**Implementation**
When the backend value is set to 1, the Mod Loader loads the file `d3d8m.dll` from the extlibs folder using `LoadLibraryEx` and hooks the game's function `Direct3DCreate8` to make it return d3d8to9's Direct3D object instead.

**Some notes**
- `d3d8.dll` in the game folder is no longer required to load d3d8to9.
- This hack is completely transparent to the game and mods, including Lantern Engine, which will detect d3dto9 correctly without any modifications.
- If it finds `d3d8.dll` in the game folder, it will assume d3d8to9 is already loaded and do nothing, so the old method of loading d3d8to9 will still work.
- In the future the backend option can be expanded with more options, such as D3D9on12.

**Things to check before merging**
- Since the file is called `d3d8m.dll` rather than `d3d8.dll`, it should now work without specifying WINE overrides in Steam startup options on Linux/Steam Deck - **needs testing**.
- The `Direct3DCreate8` function at `0x007C235E` is marked as stdcall. It's [WriteJumped](https://github.com/X-Hax/sadx-mod-loader/commit/36dca2212eeb51ee2fc776dae69edd8b8a561bc6#diff-a90f1853c7775fa7aecd041ea869e72fde8b60b6a0d1e5d3b89adf1df32f23aeR63) with [this](https://github.com/X-Hax/sadx-mod-loader/commit/36dca2212eeb51ee2fc776dae69edd8b8a561bc6#diff-a90f1853c7775fa7aecd041ea869e72fde8b60b6a0d1e5d3b89adf1df32f23aeR11). Need to double check if this can cause any issues.