### PR TITLE
Improve uiscale in pause menu

### DIFF
--- a/SADXModLoader/include/SADXFunctionsNew.h
+++ b/SADXModLoader/include/SADXFunctionsNew.h
@@ -125,6 +125,7 @@ FunctionPointer(OCMDATA*, OCMRegister, (taskwk* otwp), 0x5FE2F0);
 FunctionPointer(Bool, OCMunregister, (OCMDATA* ocmdata), 0x5FE360);
 FunctionPointer(OCMDATA*, OCMsearchRideobj, (taskwk* otwp), 0x5FE380);
 VoidFunc(calcvsyncsyoriochi, 0x413920);
+VoidFunc(SpLoopOnlyDisplay, 0x456CD0); // Display sprite queue
 
 // Filesystem
 FunctionPointer(Sint8*, njOpenBinary, (const char* fname), 0x7929D0);

--- a/SADXModLoader/uiscale.cpp
+++ b/SADXModLoader/uiscale.cpp
@@ -126,24 +126,6 @@ void uiscale::scale_pop()
 	do_scale = !scale_stack.empty();
 }
 
-static Trampoline* DisplayAllObjects_t = nullptr;
-
-static void __cdecl DisplayAllObjects_r()
-{
-	if (do_scale)
-	{
-		uiscale::scale_push(uiscale::Align_Automatic, false, uiscale::scale_h, uiscale::scale_v);
-	}
-
-	auto original = static_cast<decltype(DisplayAllObjects_r)*>(DisplayAllObjects_t->Target());
-	original();
-
-	if (do_scale)
-	{
-		uiscale::scale_pop();
-	}
-}
-
 static NJS_POINT2 auto_align(uiscale::Align align, const NJS_POINT2& center)
 {
 	using namespace uiscale;
@@ -716,9 +698,6 @@ void uiscale::initialize_common()
 void uiscale::initialize()
 {
 	initialize_common();
-
-	DisplayAllObjects_t = new Trampoline(0x0040B540, 0x0040B546, DisplayAllObjects_r);
-	WriteCall(reinterpret_cast<void*>(reinterpret_cast<size_t>(DisplayAllObjects_t->Target()) + 1), reinterpret_cast<void*>(0x004128F0));
 }
 
 void uiscale::setup_background_scale()


### PR DESCRIPTION
Currently uiscale is applied to the whole pause menu loop, which itself contains two additional loops (for the control and camera menus). The problem is that the game runs DisplayAllObjects inside each of these loops, so all task displays are UI scaled to the center.

To circumvent this, SF made task displayers run in auto scale mode while paused, but it means that uiscale is always active while paused. This presents a problem for mods that are rendering without uiscale, or that rewrite DisplayAllObjects (Multiplayer mod in both cases).

I replaced the hack with other hacks that leave DisplayAllObjects unscaled.

The only problem is that I had to do some magic for the camera and control menus, so mods won't be able to rewrite them directly. Another solution is to hack the Horizontal/VerticalStretch pointers, update the hack variables before PauseLoop runs, and only uiscale the sprite drawing wrapper.

It *should* work without issues, unless a mod is relying on this behavior but I doubt it.

Also, if you have a better idea or an input @michael-fadely ^^