### PR TITLE
Codeless Config Revamp

### DIFF
--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1271,7 +1271,6 @@ static void __cdecl InitMods()
 		CodepageGerman = modinfo->getInt("CodepageGerman", 1252);
 		CodepageSpanish = modinfo->getInt("CodepageSpanish", 1252);
 
-
 		HandleModIniContent(ini_mod.get(), modinfo, mod_dir, mod_dirA);
 
 		if (modinfo->hasKeyNonEmpty("WindowTitle"))

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1306,6 +1306,7 @@ static void __cdecl InitMods()
 							{
 								incDirPath = group->second->getString(dirStr);
 								incDirPathW = group->second->getWString(dirStr);
+								break;
 							}
 						}
 


### PR DESCRIPTION
As per discussion in X-Hax, this makes changes to the codeless config options to make use of config.ini over mod.ini for Include Directories. 

In short, the changes are as follows:
- Check mod.ini for "Config" group.
- If present, process Config data (currently only include directories)
- If the IncludeDirCount is over 0, process include directories.
- Check if a config.ini file exists for the mod.
- If one does exist, loop through the include directory count, pull defaults from mod.ini's config, and then loop through all groups in config.ini to see if the corresponding key exists and update the information from config.ini.
- If no config.ini file exists, process only the information in mod.ini.